### PR TITLE
chore: agent config update

### DIFF
--- a/.agents/hooks/simplify-on-stop.sh
+++ b/.agents/hooks/simplify-on-stop.sh
@@ -35,4 +35,4 @@ lock="${TMPDIR:-/tmp}/simplify-on-stop-${session_id}.lock"
 # the nudge for this session, which is strictly better than looping.)
 : > "$lock" 2>/dev/null || exit 0
 
-echo '{"decision":"block","reason":"Before stopping, call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\" skill). Actually walk the skill against the code you modified this session: check each touched file against the applicable .agents/rules/*.md and the skill defaults, and apply fixes — do not rubber-stamp with \"no changes needed\". If you modified no code at all, skip the skill and conclude."}'
+echo '{"decision":"block","reason":"Before stopping, call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\" skill). Actually walk the skill against the code you modified this session: check each touched file against your rules and the skill defaults, and apply fixes — do not rubber-stamp with \"no changes needed\". If you modified no code at all, skip the skill and conclude."}'

--- a/.agents/hooks/simplify-on-stop.sh
+++ b/.agents/hooks/simplify-on-stop.sh
@@ -35,4 +35,4 @@ lock="${TMPDIR:-/tmp}/simplify-on-stop-${session_id}.lock"
 # the nudge for this session, which is strictly better than looping.)
 : > "$lock" 2>/dev/null || exit 0
 
-echo '{"decision":"block","reason":"Before stopping, call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\" skill) to review code you modified this session. If you modified no code, skip the skill and conclude."}'
+echo '{"decision":"block","reason":"Before stopping, call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\" skill). Actually walk the skill against the code you modified this session: check each touched file against the applicable .agents/rules/*.md and the skill defaults, and apply fixes — do not rubber-stamp with \"no changes needed\". If you modified no code at all, skip the skill and conclude."}'

--- a/.agents/skills/code-simplify/SKILL.md
+++ b/.agents/skills/code-simplify/SKILL.md
@@ -13,7 +13,7 @@ The parent agent must indicate which mode applies. If unspecified, use **default
 
 - Refine code that has been **recently modified or touched in the current session**, unless explicitly instructed to review a broader scope.
 - Use this mode for day-to-day follow-up after edits in a single conversation.
-- Do not conclude "no changes needed" until you have walked each touched file against the applicable `.agents/rules/*.md` and the simplification defaults below. Report what you checked, not just what you changed.
+- Do not conclude "no changes needed" until you have walked each touched file against your rules and the simplification defaults below. Report what you checked, not just what you changed.
 - Consistency with siblings counts: if a touched file inlines literals, types, or props for some siblings but not for the one you added, treat that as a finding and fix it.
 
 ### Orchestrated mode
@@ -35,7 +35,7 @@ You will analyze code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Defer to the repository's own conventions — follow `.agents/rules/` for the languages and paths you touch (for example `.agents/rules/python.md`, `.agents/rules/testing.md` under `tests/`) and `CLAUDE.md`. Do not assume framework or library conventions that this repository's rules do not declare.
+2. **Apply Project Standards**: Defer to the repository's own conventions — follow your rules for the languages and paths you touch, plus `CLAUDE.md`. Do not assume framework or library conventions that this repository's rules do not declare.
 
 3. **Enhance Clarity**: Simplify code structure by:
 
@@ -43,7 +43,7 @@ You will analyze code and apply refinements that:
    - Eliminating redundant code and abstractions
    - Improving readability through clear variable and function names
    - Consolidating related logic
-   - Removing redundant `#` comments that restate obvious code (never treat docstrings as removable comments; keep or add one-line docstrings on functions, methods, and classes per `.agents/rules/python.md`)
+   - Removing redundant `#` comments that restate obvious code (never treat docstrings as removable comments; keep or add one-line docstrings on functions, methods, and classes per your Python rules)
    - IMPORTANT: Avoid nested ternary operators - prefer if/else chains for multiple conditions
    - Choose clarity over brevity - explicit code is often better than overly compact code
 
@@ -67,7 +67,7 @@ You will analyze code and apply refinements that:
 
 1. Identify the recently modified code sections
 2. Analyze for opportunities to improve elegance and consistency
-3. Apply `.agents/rules/` for applicable file types and paths, and project standards from `.claude/CLAUDE.md` and `.claude/rules/` where they apply
+3. Apply your rules for applicable file types and paths, and project standards from `CLAUDE.md` where they apply
 4. Ensure all functionality remains unchanged
 5. Verify the refined code is simpler and more maintainable
 6. Document only significant changes that affect understanding
@@ -76,7 +76,7 @@ You will analyze code and apply refinements that:
 
 1. Enumerate or discover files under the given scope (respect excludes such as generated clients and lockfiles when the parent lists them)
 2. Analyze for simplification opportunities consistent with this skill
-3. Apply `.agents/rules/` for each touched file (for example `.agents/rules/python.md` for Python, `.agents/rules/testing.md` under `tests/`), and project standards from `.claude/CLAUDE.md` and `.claude/rules/` where they apply
+3. Apply your rules for each touched file (Python rules for Python, testing rules under `tests/`, and so on), and project standards from `CLAUDE.md` where they apply
 4. Ensure all functionality remains unchanged
 5. Run or specify tests the parent should run for this scope when feasible
 6. Report files changed, summary of edits, and any scope spill or contract risk

--- a/.agents/skills/code-simplify/SKILL.md
+++ b/.agents/skills/code-simplify/SKILL.md
@@ -35,14 +35,7 @@ You will analyze code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Follow `.agents/rules/` for the languages and paths you touch (for example `.agents/rules/python.md`, `.agents/rules/testing.md` under `tests/`), and established standards from `CLAUDE.md` where applicable, including:
-
-   - Use modern Python type hints (`str | None`, `list[T]`, etc.)
-   - Prefer `BaseModel` over dataclasses or `TypedDict` when validation/serialization is needed
-   - Use `BaseEnum` from `vaultgig_common` for string enums
-   - Follow proper FastAPI patterns (thin route handlers, service delegation)
-   - Use appropriate log levels and the `logging` module instead of `print`
-   - Maintain consistent naming conventions
+2. **Apply Project Standards**: Defer to the repository's own conventions — follow `.agents/rules/` for the languages and paths you touch (for example `.agents/rules/python.md`, `.agents/rules/testing.md` under `tests/`) and `CLAUDE.md`. Do not assume framework or library conventions that this repository's rules do not declare.
 
 3. **Enhance Clarity**: Simplify code structure by:
 

--- a/.agents/skills/code-simplify/SKILL.md
+++ b/.agents/skills/code-simplify/SKILL.md
@@ -35,7 +35,7 @@ You will analyze code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Defer to the repository's own conventions — follow your rules for the languages and paths you touch, plus `CLAUDE.md`. Do not assume framework or library conventions that this repository's rules do not declare.
+2. **Apply Project Standards**: Defer to the repository's own conventions — follow your rules for the languages and paths you touch. Do not assume framework or library conventions that this repository's rules do not declare.
 
 3. **Enhance Clarity**: Simplify code structure by:
 
@@ -67,7 +67,7 @@ You will analyze code and apply refinements that:
 
 1. Identify the recently modified code sections
 2. Analyze for opportunities to improve elegance and consistency
-3. Apply your rules for applicable file types and paths, and project standards from `CLAUDE.md` where they apply
+3. Apply your rules for applicable file types and paths
 4. Ensure all functionality remains unchanged
 5. Verify the refined code is simpler and more maintainable
 6. Document only significant changes that affect understanding
@@ -76,7 +76,7 @@ You will analyze code and apply refinements that:
 
 1. Enumerate or discover files under the given scope (respect excludes such as generated clients and lockfiles when the parent lists them)
 2. Analyze for simplification opportunities consistent with this skill
-3. Apply your rules for each touched file (Python rules for Python, testing rules under `tests/`, and so on), and project standards from `CLAUDE.md` where they apply
+3. Apply your rules for each touched file (Python rules for Python, testing rules under `tests/`, and so on)
 4. Ensure all functionality remains unchanged
 5. Run or specify tests the parent should run for this scope when feasible
 6. Report files changed, summary of edits, and any scope spill or contract risk

--- a/.agents/skills/code-simplify/SKILL.md
+++ b/.agents/skills/code-simplify/SKILL.md
@@ -13,10 +13,12 @@ The parent agent must indicate which mode applies. If unspecified, use **default
 
 - Refine code that has been **recently modified or touched in the current session**, unless explicitly instructed to review a broader scope.
 - Use this mode for day-to-day follow-up after edits in a single conversation.
+- Do not conclude "no changes needed" until you have walked each touched file against the applicable `.agents/rules/*.md` and the simplification defaults below. Report what you checked, not just what you changed.
+- Consistency with siblings counts: if a touched file inlines literals, types, or props for some siblings but not for the one you added, treat that as a finding and fix it.
 
 ### Orchestrated mode
 
-- The parent provides a **bounded scope**: explicit path list, glob, and/or service or package prefix.
+- The parent provides a **bounded scope**: explicit path list, glob, and/or service or package prefix (for example a shard under `apps/` or `packages/`).
 - You may analyze and refine **any file within that scope**, not only lines changed in the current session.
 - Use this mode when spawned as **`shard-executor`** with **`executor_kind: simplify`**, or when the user explicitly names directories or files to simplify.
 
@@ -33,7 +35,14 @@ You will analyze code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Defer to the repository's own conventions. Check `CLAUDE.md`, `.claude/rules/`, `.cursor/rules/`, `.agents/rules/`, and any project style/linting configuration that already exists, and follow the patterns established there. Do not invent or import standards from outside the repository — if a convention is not encoded somewhere in the repo, prefer the patterns already used in nearby code over introducing a new style.
+2. **Apply Project Standards**: Follow `.agents/rules/` for the languages and paths you touch (for example `.agents/rules/python.md`, `.agents/rules/testing.md` under `tests/`), and established standards from `CLAUDE.md` where applicable, including:
+
+   - Use modern Python type hints (`str | None`, `list[T]`, etc.)
+   - Prefer `BaseModel` over dataclasses or `TypedDict` when validation/serialization is needed
+   - Use `BaseEnum` from `vaultgig_common` for string enums
+   - Follow proper FastAPI patterns (thin route handlers, service delegation)
+   - Use appropriate log levels and the `logging` module instead of `print`
+   - Maintain consistent naming conventions
 
 3. **Enhance Clarity**: Simplify code structure by:
 
@@ -41,7 +50,7 @@ You will analyze code and apply refinements that:
    - Eliminating redundant code and abstractions
    - Improving readability through clear variable and function names
    - Consolidating related logic
-   - Removing redundant comments that restate obvious code (keep docstrings and comments that explain non-obvious **why**)
+   - Removing redundant `#` comments that restate obvious code (never treat docstrings as removable comments; keep or add one-line docstrings on functions, methods, and classes per `.agents/rules/python.md`)
    - IMPORTANT: Avoid nested ternary operators - prefer if/else chains for multiple conditions
    - Choose clarity over brevity - explicit code is often better than overly compact code
 
@@ -65,7 +74,7 @@ You will analyze code and apply refinements that:
 
 1. Identify the recently modified code sections
 2. Analyze for opportunities to improve elegance and consistency
-3. Apply the repository's own conventions (see "Apply Project Standards" above)
+3. Apply `.agents/rules/` for applicable file types and paths, and project standards from `.claude/CLAUDE.md` and `.claude/rules/` where they apply
 4. Ensure all functionality remains unchanged
 5. Verify the refined code is simpler and more maintainable
 6. Document only significant changes that affect understanding
@@ -74,7 +83,7 @@ You will analyze code and apply refinements that:
 
 1. Enumerate or discover files under the given scope (respect excludes such as generated clients and lockfiles when the parent lists them)
 2. Analyze for simplification opportunities consistent with this skill
-3. Apply the repository's own conventions (see "Apply Project Standards" above)
+3. Apply `.agents/rules/` for each touched file (for example `.agents/rules/python.md` for Python, `.agents/rules/testing.md` under `tests/`), and project standards from `.claude/CLAUDE.md` and `.claude/rules/` where they apply
 4. Ensure all functionality remains unchanged
 5. Run or specify tests the parent should run for this scope when feasible
 6. Report files changed, summary of edits, and any scope spill or contract risk

--- a/.claude/hooks/simplify-on-stop.sh
+++ b/.claude/hooks/simplify-on-stop.sh
@@ -35,4 +35,4 @@ lock="${TMPDIR:-/tmp}/simplify-on-stop-${session_id}.lock"
 # the nudge for this session, which is strictly better than looping.)
 : > "$lock" 2>/dev/null || exit 0
 
-echo '{"decision":"block","reason":"Before stopping, call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\" skill). Actually walk the skill against the code you modified this session: check each touched file against the applicable .agents/rules/*.md and the skill defaults, and apply fixes — do not rubber-stamp with \"no changes needed\". If you modified no code at all, skip the skill and conclude."}'
+echo '{"decision":"block","reason":"Before stopping, call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\" skill). Actually walk the skill against the code you modified this session: check each touched file against your rules and the skill defaults, and apply fixes — do not rubber-stamp with \"no changes needed\". If you modified no code at all, skip the skill and conclude."}'

--- a/.claude/hooks/simplify-on-stop.sh
+++ b/.claude/hooks/simplify-on-stop.sh
@@ -35,4 +35,4 @@ lock="${TMPDIR:-/tmp}/simplify-on-stop-${session_id}.lock"
 # the nudge for this session, which is strictly better than looping.)
 : > "$lock" 2>/dev/null || exit 0
 
-echo '{"decision":"block","reason":"Before stopping, call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\" skill) to review code you modified this session. If you modified no code, skip the skill and conclude."}'
+echo '{"decision":"block","reason":"Before stopping, call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\" skill). Actually walk the skill against the code you modified this session: check each touched file against the applicable .agents/rules/*.md and the skill defaults, and apply fixes — do not rubber-stamp with \"no changes needed\". If you modified no code at all, skip the skill and conclude."}'

--- a/.claude/skills/code-simplify/SKILL.md
+++ b/.claude/skills/code-simplify/SKILL.md
@@ -13,7 +13,7 @@ The parent agent must indicate which mode applies. If unspecified, use **default
 
 - Refine code that has been **recently modified or touched in the current session**, unless explicitly instructed to review a broader scope.
 - Use this mode for day-to-day follow-up after edits in a single conversation.
-- Do not conclude "no changes needed" until you have walked each touched file against the applicable `.agents/rules/*.md` and the simplification defaults below. Report what you checked, not just what you changed.
+- Do not conclude "no changes needed" until you have walked each touched file against your rules and the simplification defaults below. Report what you checked, not just what you changed.
 - Consistency with siblings counts: if a touched file inlines literals, types, or props for some siblings but not for the one you added, treat that as a finding and fix it.
 
 ### Orchestrated mode
@@ -35,7 +35,7 @@ You will analyze code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Defer to the repository's own conventions — follow `.agents/rules/` for the languages and paths you touch (for example `.agents/rules/python.md`, `.agents/rules/testing.md` under `tests/`) and `CLAUDE.md`. Do not assume framework or library conventions that this repository's rules do not declare.
+2. **Apply Project Standards**: Defer to the repository's own conventions — follow your rules for the languages and paths you touch, plus `CLAUDE.md`. Do not assume framework or library conventions that this repository's rules do not declare.
 
 3. **Enhance Clarity**: Simplify code structure by:
 
@@ -43,7 +43,7 @@ You will analyze code and apply refinements that:
    - Eliminating redundant code and abstractions
    - Improving readability through clear variable and function names
    - Consolidating related logic
-   - Removing redundant `#` comments that restate obvious code (never treat docstrings as removable comments; keep or add one-line docstrings on functions, methods, and classes per `.agents/rules/python.md`)
+   - Removing redundant `#` comments that restate obvious code (never treat docstrings as removable comments; keep or add one-line docstrings on functions, methods, and classes per your Python rules)
    - IMPORTANT: Avoid nested ternary operators - prefer if/else chains for multiple conditions
    - Choose clarity over brevity - explicit code is often better than overly compact code
 
@@ -67,7 +67,7 @@ You will analyze code and apply refinements that:
 
 1. Identify the recently modified code sections
 2. Analyze for opportunities to improve elegance and consistency
-3. Apply `.agents/rules/` for applicable file types and paths, and project standards from `.claude/CLAUDE.md` and `.claude/rules/` where they apply
+3. Apply your rules for applicable file types and paths, and project standards from `CLAUDE.md` where they apply
 4. Ensure all functionality remains unchanged
 5. Verify the refined code is simpler and more maintainable
 6. Document only significant changes that affect understanding
@@ -76,7 +76,7 @@ You will analyze code and apply refinements that:
 
 1. Enumerate or discover files under the given scope (respect excludes such as generated clients and lockfiles when the parent lists them)
 2. Analyze for simplification opportunities consistent with this skill
-3. Apply `.agents/rules/` for each touched file (for example `.agents/rules/python.md` for Python, `.agents/rules/testing.md` under `tests/`), and project standards from `.claude/CLAUDE.md` and `.claude/rules/` where they apply
+3. Apply your rules for each touched file (Python rules for Python, testing rules under `tests/`, and so on), and project standards from `CLAUDE.md` where they apply
 4. Ensure all functionality remains unchanged
 5. Run or specify tests the parent should run for this scope when feasible
 6. Report files changed, summary of edits, and any scope spill or contract risk

--- a/.claude/skills/code-simplify/SKILL.md
+++ b/.claude/skills/code-simplify/SKILL.md
@@ -35,14 +35,7 @@ You will analyze code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Follow `.agents/rules/` for the languages and paths you touch (for example `.agents/rules/python.md`, `.agents/rules/testing.md` under `tests/`), and established standards from `CLAUDE.md` where applicable, including:
-
-   - Use modern Python type hints (`str | None`, `list[T]`, etc.)
-   - Prefer `BaseModel` over dataclasses or `TypedDict` when validation/serialization is needed
-   - Use `BaseEnum` from `vaultgig_common` for string enums
-   - Follow proper FastAPI patterns (thin route handlers, service delegation)
-   - Use appropriate log levels and the `logging` module instead of `print`
-   - Maintain consistent naming conventions
+2. **Apply Project Standards**: Defer to the repository's own conventions — follow `.agents/rules/` for the languages and paths you touch (for example `.agents/rules/python.md`, `.agents/rules/testing.md` under `tests/`) and `CLAUDE.md`. Do not assume framework or library conventions that this repository's rules do not declare.
 
 3. **Enhance Clarity**: Simplify code structure by:
 

--- a/.claude/skills/code-simplify/SKILL.md
+++ b/.claude/skills/code-simplify/SKILL.md
@@ -35,7 +35,7 @@ You will analyze code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Defer to the repository's own conventions — follow your rules for the languages and paths you touch, plus `CLAUDE.md`. Do not assume framework or library conventions that this repository's rules do not declare.
+2. **Apply Project Standards**: Defer to the repository's own conventions — follow your rules for the languages and paths you touch. Do not assume framework or library conventions that this repository's rules do not declare.
 
 3. **Enhance Clarity**: Simplify code structure by:
 
@@ -67,7 +67,7 @@ You will analyze code and apply refinements that:
 
 1. Identify the recently modified code sections
 2. Analyze for opportunities to improve elegance and consistency
-3. Apply your rules for applicable file types and paths, and project standards from `CLAUDE.md` where they apply
+3. Apply your rules for applicable file types and paths
 4. Ensure all functionality remains unchanged
 5. Verify the refined code is simpler and more maintainable
 6. Document only significant changes that affect understanding
@@ -76,7 +76,7 @@ You will analyze code and apply refinements that:
 
 1. Enumerate or discover files under the given scope (respect excludes such as generated clients and lockfiles when the parent lists them)
 2. Analyze for simplification opportunities consistent with this skill
-3. Apply your rules for each touched file (Python rules for Python, testing rules under `tests/`, and so on), and project standards from `CLAUDE.md` where they apply
+3. Apply your rules for each touched file (Python rules for Python, testing rules under `tests/`, and so on)
 4. Ensure all functionality remains unchanged
 5. Run or specify tests the parent should run for this scope when feasible
 6. Report files changed, summary of edits, and any scope spill or contract risk

--- a/.claude/skills/code-simplify/SKILL.md
+++ b/.claude/skills/code-simplify/SKILL.md
@@ -13,10 +13,12 @@ The parent agent must indicate which mode applies. If unspecified, use **default
 
 - Refine code that has been **recently modified or touched in the current session**, unless explicitly instructed to review a broader scope.
 - Use this mode for day-to-day follow-up after edits in a single conversation.
+- Do not conclude "no changes needed" until you have walked each touched file against the applicable `.agents/rules/*.md` and the simplification defaults below. Report what you checked, not just what you changed.
+- Consistency with siblings counts: if a touched file inlines literals, types, or props for some siblings but not for the one you added, treat that as a finding and fix it.
 
 ### Orchestrated mode
 
-- The parent provides a **bounded scope**: explicit path list, glob, and/or service or package prefix.
+- The parent provides a **bounded scope**: explicit path list, glob, and/or service or package prefix (for example a shard under `apps/` or `packages/`).
 - You may analyze and refine **any file within that scope**, not only lines changed in the current session.
 - Use this mode when spawned as **`shard-executor`** with **`executor_kind: simplify`**, or when the user explicitly names directories or files to simplify.
 
@@ -33,7 +35,14 @@ You will analyze code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Defer to the repository's own conventions. Check `CLAUDE.md`, `.claude/rules/`, `.cursor/rules/`, `.agents/rules/`, and any project style/linting configuration that already exists, and follow the patterns established there. Do not invent or import standards from outside the repository — if a convention is not encoded somewhere in the repo, prefer the patterns already used in nearby code over introducing a new style.
+2. **Apply Project Standards**: Follow `.agents/rules/` for the languages and paths you touch (for example `.agents/rules/python.md`, `.agents/rules/testing.md` under `tests/`), and established standards from `CLAUDE.md` where applicable, including:
+
+   - Use modern Python type hints (`str | None`, `list[T]`, etc.)
+   - Prefer `BaseModel` over dataclasses or `TypedDict` when validation/serialization is needed
+   - Use `BaseEnum` from `vaultgig_common` for string enums
+   - Follow proper FastAPI patterns (thin route handlers, service delegation)
+   - Use appropriate log levels and the `logging` module instead of `print`
+   - Maintain consistent naming conventions
 
 3. **Enhance Clarity**: Simplify code structure by:
 
@@ -41,7 +50,7 @@ You will analyze code and apply refinements that:
    - Eliminating redundant code and abstractions
    - Improving readability through clear variable and function names
    - Consolidating related logic
-   - Removing redundant comments that restate obvious code (keep docstrings and comments that explain non-obvious **why**)
+   - Removing redundant `#` comments that restate obvious code (never treat docstrings as removable comments; keep or add one-line docstrings on functions, methods, and classes per `.agents/rules/python.md`)
    - IMPORTANT: Avoid nested ternary operators - prefer if/else chains for multiple conditions
    - Choose clarity over brevity - explicit code is often better than overly compact code
 
@@ -65,7 +74,7 @@ You will analyze code and apply refinements that:
 
 1. Identify the recently modified code sections
 2. Analyze for opportunities to improve elegance and consistency
-3. Apply the repository's own conventions (see "Apply Project Standards" above)
+3. Apply `.agents/rules/` for applicable file types and paths, and project standards from `.claude/CLAUDE.md` and `.claude/rules/` where they apply
 4. Ensure all functionality remains unchanged
 5. Verify the refined code is simpler and more maintainable
 6. Document only significant changes that affect understanding
@@ -74,7 +83,7 @@ You will analyze code and apply refinements that:
 
 1. Enumerate or discover files under the given scope (respect excludes such as generated clients and lockfiles when the parent lists them)
 2. Analyze for simplification opportunities consistent with this skill
-3. Apply the repository's own conventions (see "Apply Project Standards" above)
+3. Apply `.agents/rules/` for each touched file (for example `.agents/rules/python.md` for Python, `.agents/rules/testing.md` under `tests/`), and project standards from `.claude/CLAUDE.md` and `.claude/rules/` where they apply
 4. Ensure all functionality remains unchanged
 5. Run or specify tests the parent should run for this scope when feasible
 6. Report files changed, summary of edits, and any scope spill or contract risk

--- a/.codex/skills/code-simplify/SKILL.md
+++ b/.codex/skills/code-simplify/SKILL.md
@@ -13,7 +13,7 @@ The parent agent must indicate which mode applies. If unspecified, use **default
 
 - Refine code that has been **recently modified or touched in the current session**, unless explicitly instructed to review a broader scope.
 - Use this mode for day-to-day follow-up after edits in a single conversation.
-- Do not conclude "no changes needed" until you have walked each touched file against the applicable `.agents/rules/*.md` and the simplification defaults below. Report what you checked, not just what you changed.
+- Do not conclude "no changes needed" until you have walked each touched file against your rules and the simplification defaults below. Report what you checked, not just what you changed.
 - Consistency with siblings counts: if a touched file inlines literals, types, or props for some siblings but not for the one you added, treat that as a finding and fix it.
 
 ### Orchestrated mode
@@ -35,7 +35,7 @@ You will analyze code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Defer to the repository's own conventions — follow `.agents/rules/` for the languages and paths you touch (for example `.agents/rules/python.md`, `.agents/rules/testing.md` under `tests/`) and `CLAUDE.md`. Do not assume framework or library conventions that this repository's rules do not declare.
+2. **Apply Project Standards**: Defer to the repository's own conventions — follow your rules for the languages and paths you touch, plus `CLAUDE.md`. Do not assume framework or library conventions that this repository's rules do not declare.
 
 3. **Enhance Clarity**: Simplify code structure by:
 
@@ -43,7 +43,7 @@ You will analyze code and apply refinements that:
    - Eliminating redundant code and abstractions
    - Improving readability through clear variable and function names
    - Consolidating related logic
-   - Removing redundant `#` comments that restate obvious code (never treat docstrings as removable comments; keep or add one-line docstrings on functions, methods, and classes per `.agents/rules/python.md`)
+   - Removing redundant `#` comments that restate obvious code (never treat docstrings as removable comments; keep or add one-line docstrings on functions, methods, and classes per your Python rules)
    - IMPORTANT: Avoid nested ternary operators - prefer if/else chains for multiple conditions
    - Choose clarity over brevity - explicit code is often better than overly compact code
 
@@ -67,7 +67,7 @@ You will analyze code and apply refinements that:
 
 1. Identify the recently modified code sections
 2. Analyze for opportunities to improve elegance and consistency
-3. Apply `.agents/rules/` for applicable file types and paths, and project standards from `.claude/CLAUDE.md` and `.claude/rules/` where they apply
+3. Apply your rules for applicable file types and paths, and project standards from `CLAUDE.md` where they apply
 4. Ensure all functionality remains unchanged
 5. Verify the refined code is simpler and more maintainable
 6. Document only significant changes that affect understanding
@@ -76,7 +76,7 @@ You will analyze code and apply refinements that:
 
 1. Enumerate or discover files under the given scope (respect excludes such as generated clients and lockfiles when the parent lists them)
 2. Analyze for simplification opportunities consistent with this skill
-3. Apply `.agents/rules/` for each touched file (for example `.agents/rules/python.md` for Python, `.agents/rules/testing.md` under `tests/`), and project standards from `.claude/CLAUDE.md` and `.claude/rules/` where they apply
+3. Apply your rules for each touched file (Python rules for Python, testing rules under `tests/`, and so on), and project standards from `CLAUDE.md` where they apply
 4. Ensure all functionality remains unchanged
 5. Run or specify tests the parent should run for this scope when feasible
 6. Report files changed, summary of edits, and any scope spill or contract risk

--- a/.codex/skills/code-simplify/SKILL.md
+++ b/.codex/skills/code-simplify/SKILL.md
@@ -35,14 +35,7 @@ You will analyze code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Follow `.agents/rules/` for the languages and paths you touch (for example `.agents/rules/python.md`, `.agents/rules/testing.md` under `tests/`), and established standards from `CLAUDE.md` where applicable, including:
-
-   - Use modern Python type hints (`str | None`, `list[T]`, etc.)
-   - Prefer `BaseModel` over dataclasses or `TypedDict` when validation/serialization is needed
-   - Use `BaseEnum` from `vaultgig_common` for string enums
-   - Follow proper FastAPI patterns (thin route handlers, service delegation)
-   - Use appropriate log levels and the `logging` module instead of `print`
-   - Maintain consistent naming conventions
+2. **Apply Project Standards**: Defer to the repository's own conventions — follow `.agents/rules/` for the languages and paths you touch (for example `.agents/rules/python.md`, `.agents/rules/testing.md` under `tests/`) and `CLAUDE.md`. Do not assume framework or library conventions that this repository's rules do not declare.
 
 3. **Enhance Clarity**: Simplify code structure by:
 

--- a/.codex/skills/code-simplify/SKILL.md
+++ b/.codex/skills/code-simplify/SKILL.md
@@ -35,7 +35,7 @@ You will analyze code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Defer to the repository's own conventions — follow your rules for the languages and paths you touch, plus `CLAUDE.md`. Do not assume framework or library conventions that this repository's rules do not declare.
+2. **Apply Project Standards**: Defer to the repository's own conventions — follow your rules for the languages and paths you touch. Do not assume framework or library conventions that this repository's rules do not declare.
 
 3. **Enhance Clarity**: Simplify code structure by:
 
@@ -67,7 +67,7 @@ You will analyze code and apply refinements that:
 
 1. Identify the recently modified code sections
 2. Analyze for opportunities to improve elegance and consistency
-3. Apply your rules for applicable file types and paths, and project standards from `CLAUDE.md` where they apply
+3. Apply your rules for applicable file types and paths
 4. Ensure all functionality remains unchanged
 5. Verify the refined code is simpler and more maintainable
 6. Document only significant changes that affect understanding
@@ -76,7 +76,7 @@ You will analyze code and apply refinements that:
 
 1. Enumerate or discover files under the given scope (respect excludes such as generated clients and lockfiles when the parent lists them)
 2. Analyze for simplification opportunities consistent with this skill
-3. Apply your rules for each touched file (Python rules for Python, testing rules under `tests/`, and so on), and project standards from `CLAUDE.md` where they apply
+3. Apply your rules for each touched file (Python rules for Python, testing rules under `tests/`, and so on)
 4. Ensure all functionality remains unchanged
 5. Run or specify tests the parent should run for this scope when feasible
 6. Report files changed, summary of edits, and any scope spill or contract risk

--- a/.codex/skills/code-simplify/SKILL.md
+++ b/.codex/skills/code-simplify/SKILL.md
@@ -13,10 +13,12 @@ The parent agent must indicate which mode applies. If unspecified, use **default
 
 - Refine code that has been **recently modified or touched in the current session**, unless explicitly instructed to review a broader scope.
 - Use this mode for day-to-day follow-up after edits in a single conversation.
+- Do not conclude "no changes needed" until you have walked each touched file against the applicable `.agents/rules/*.md` and the simplification defaults below. Report what you checked, not just what you changed.
+- Consistency with siblings counts: if a touched file inlines literals, types, or props for some siblings but not for the one you added, treat that as a finding and fix it.
 
 ### Orchestrated mode
 
-- The parent provides a **bounded scope**: explicit path list, glob, and/or service or package prefix.
+- The parent provides a **bounded scope**: explicit path list, glob, and/or service or package prefix (for example a shard under `apps/` or `packages/`).
 - You may analyze and refine **any file within that scope**, not only lines changed in the current session.
 - Use this mode when spawned as **`shard-executor`** with **`executor_kind: simplify`**, or when the user explicitly names directories or files to simplify.
 
@@ -33,7 +35,14 @@ You will analyze code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Defer to the repository's own conventions. Check `CLAUDE.md`, `.claude/rules/`, `.cursor/rules/`, `.agents/rules/`, and any project style/linting configuration that already exists, and follow the patterns established there. Do not invent or import standards from outside the repository — if a convention is not encoded somewhere in the repo, prefer the patterns already used in nearby code over introducing a new style.
+2. **Apply Project Standards**: Follow `.agents/rules/` for the languages and paths you touch (for example `.agents/rules/python.md`, `.agents/rules/testing.md` under `tests/`), and established standards from `CLAUDE.md` where applicable, including:
+
+   - Use modern Python type hints (`str | None`, `list[T]`, etc.)
+   - Prefer `BaseModel` over dataclasses or `TypedDict` when validation/serialization is needed
+   - Use `BaseEnum` from `vaultgig_common` for string enums
+   - Follow proper FastAPI patterns (thin route handlers, service delegation)
+   - Use appropriate log levels and the `logging` module instead of `print`
+   - Maintain consistent naming conventions
 
 3. **Enhance Clarity**: Simplify code structure by:
 
@@ -41,7 +50,7 @@ You will analyze code and apply refinements that:
    - Eliminating redundant code and abstractions
    - Improving readability through clear variable and function names
    - Consolidating related logic
-   - Removing redundant comments that restate obvious code (keep docstrings and comments that explain non-obvious **why**)
+   - Removing redundant `#` comments that restate obvious code (never treat docstrings as removable comments; keep or add one-line docstrings on functions, methods, and classes per `.agents/rules/python.md`)
    - IMPORTANT: Avoid nested ternary operators - prefer if/else chains for multiple conditions
    - Choose clarity over brevity - explicit code is often better than overly compact code
 
@@ -65,7 +74,7 @@ You will analyze code and apply refinements that:
 
 1. Identify the recently modified code sections
 2. Analyze for opportunities to improve elegance and consistency
-3. Apply the repository's own conventions (see "Apply Project Standards" above)
+3. Apply `.agents/rules/` for applicable file types and paths, and project standards from `.claude/CLAUDE.md` and `.claude/rules/` where they apply
 4. Ensure all functionality remains unchanged
 5. Verify the refined code is simpler and more maintainable
 6. Document only significant changes that affect understanding
@@ -74,7 +83,7 @@ You will analyze code and apply refinements that:
 
 1. Enumerate or discover files under the given scope (respect excludes such as generated clients and lockfiles when the parent lists them)
 2. Analyze for simplification opportunities consistent with this skill
-3. Apply the repository's own conventions (see "Apply Project Standards" above)
+3. Apply `.agents/rules/` for each touched file (for example `.agents/rules/python.md` for Python, `.agents/rules/testing.md` under `tests/`), and project standards from `.claude/CLAUDE.md` and `.claude/rules/` where they apply
 4. Ensure all functionality remains unchanged
 5. Run or specify tests the parent should run for this scope when feasible
 6. Report files changed, summary of edits, and any scope spill or contract risk

--- a/.cursor/hooks/simplify-on-stop.sh
+++ b/.cursor/hooks/simplify-on-stop.sh
@@ -35,4 +35,4 @@ lock="${TMPDIR:-/tmp}/simplify-on-stop-${session_id}.lock"
 # the nudge for this session, which is strictly better than looping.)
 : > "$lock" 2>/dev/null || exit 0
 
-echo '{"decision":"block","reason":"Before stopping, call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\" skill). Actually walk the skill against the code you modified this session: check each touched file against the applicable .agents/rules/*.md and the skill defaults, and apply fixes — do not rubber-stamp with \"no changes needed\". If you modified no code at all, skip the skill and conclude."}'
+echo '{"decision":"block","reason":"Before stopping, call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\" skill). Actually walk the skill against the code you modified this session: check each touched file against your rules and the skill defaults, and apply fixes — do not rubber-stamp with \"no changes needed\". If you modified no code at all, skip the skill and conclude."}'

--- a/.cursor/hooks/simplify-on-stop.sh
+++ b/.cursor/hooks/simplify-on-stop.sh
@@ -35,4 +35,4 @@ lock="${TMPDIR:-/tmp}/simplify-on-stop-${session_id}.lock"
 # the nudge for this session, which is strictly better than looping.)
 : > "$lock" 2>/dev/null || exit 0
 
-echo '{"decision":"block","reason":"Before stopping, call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\" skill) to review code you modified this session. If you modified no code, skip the skill and conclude."}'
+echo '{"decision":"block","reason":"Before stopping, call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\" skill). Actually walk the skill against the code you modified this session: check each touched file against the applicable .agents/rules/*.md and the skill defaults, and apply fixes — do not rubber-stamp with \"no changes needed\". If you modified no code at all, skip the skill and conclude."}'

--- a/.cursor/skills/code-simplify/SKILL.md
+++ b/.cursor/skills/code-simplify/SKILL.md
@@ -13,7 +13,7 @@ The parent agent must indicate which mode applies. If unspecified, use **default
 
 - Refine code that has been **recently modified or touched in the current session**, unless explicitly instructed to review a broader scope.
 - Use this mode for day-to-day follow-up after edits in a single conversation.
-- Do not conclude "no changes needed" until you have walked each touched file against the applicable `.agents/rules/*.md` and the simplification defaults below. Report what you checked, not just what you changed.
+- Do not conclude "no changes needed" until you have walked each touched file against your rules and the simplification defaults below. Report what you checked, not just what you changed.
 - Consistency with siblings counts: if a touched file inlines literals, types, or props for some siblings but not for the one you added, treat that as a finding and fix it.
 
 ### Orchestrated mode
@@ -35,7 +35,7 @@ You will analyze code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Defer to the repository's own conventions — follow `.agents/rules/` for the languages and paths you touch (for example `.agents/rules/python.md`, `.agents/rules/testing.md` under `tests/`) and `CLAUDE.md`. Do not assume framework or library conventions that this repository's rules do not declare.
+2. **Apply Project Standards**: Defer to the repository's own conventions — follow your rules for the languages and paths you touch, plus `CLAUDE.md`. Do not assume framework or library conventions that this repository's rules do not declare.
 
 3. **Enhance Clarity**: Simplify code structure by:
 
@@ -43,7 +43,7 @@ You will analyze code and apply refinements that:
    - Eliminating redundant code and abstractions
    - Improving readability through clear variable and function names
    - Consolidating related logic
-   - Removing redundant `#` comments that restate obvious code (never treat docstrings as removable comments; keep or add one-line docstrings on functions, methods, and classes per `.agents/rules/python.md`)
+   - Removing redundant `#` comments that restate obvious code (never treat docstrings as removable comments; keep or add one-line docstrings on functions, methods, and classes per your Python rules)
    - IMPORTANT: Avoid nested ternary operators - prefer if/else chains for multiple conditions
    - Choose clarity over brevity - explicit code is often better than overly compact code
 
@@ -67,7 +67,7 @@ You will analyze code and apply refinements that:
 
 1. Identify the recently modified code sections
 2. Analyze for opportunities to improve elegance and consistency
-3. Apply `.agents/rules/` for applicable file types and paths, and project standards from `.claude/CLAUDE.md` and `.claude/rules/` where they apply
+3. Apply your rules for applicable file types and paths, and project standards from `CLAUDE.md` where they apply
 4. Ensure all functionality remains unchanged
 5. Verify the refined code is simpler and more maintainable
 6. Document only significant changes that affect understanding
@@ -76,7 +76,7 @@ You will analyze code and apply refinements that:
 
 1. Enumerate or discover files under the given scope (respect excludes such as generated clients and lockfiles when the parent lists them)
 2. Analyze for simplification opportunities consistent with this skill
-3. Apply `.agents/rules/` for each touched file (for example `.agents/rules/python.md` for Python, `.agents/rules/testing.md` under `tests/`), and project standards from `.claude/CLAUDE.md` and `.claude/rules/` where they apply
+3. Apply your rules for each touched file (Python rules for Python, testing rules under `tests/`, and so on), and project standards from `CLAUDE.md` where they apply
 4. Ensure all functionality remains unchanged
 5. Run or specify tests the parent should run for this scope when feasible
 6. Report files changed, summary of edits, and any scope spill or contract risk

--- a/.cursor/skills/code-simplify/SKILL.md
+++ b/.cursor/skills/code-simplify/SKILL.md
@@ -35,14 +35,7 @@ You will analyze code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Follow `.agents/rules/` for the languages and paths you touch (for example `.agents/rules/python.md`, `.agents/rules/testing.md` under `tests/`), and established standards from `CLAUDE.md` where applicable, including:
-
-   - Use modern Python type hints (`str | None`, `list[T]`, etc.)
-   - Prefer `BaseModel` over dataclasses or `TypedDict` when validation/serialization is needed
-   - Use `BaseEnum` from `vaultgig_common` for string enums
-   - Follow proper FastAPI patterns (thin route handlers, service delegation)
-   - Use appropriate log levels and the `logging` module instead of `print`
-   - Maintain consistent naming conventions
+2. **Apply Project Standards**: Defer to the repository's own conventions — follow `.agents/rules/` for the languages and paths you touch (for example `.agents/rules/python.md`, `.agents/rules/testing.md` under `tests/`) and `CLAUDE.md`. Do not assume framework or library conventions that this repository's rules do not declare.
 
 3. **Enhance Clarity**: Simplify code structure by:
 

--- a/.cursor/skills/code-simplify/SKILL.md
+++ b/.cursor/skills/code-simplify/SKILL.md
@@ -35,7 +35,7 @@ You will analyze code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Defer to the repository's own conventions — follow your rules for the languages and paths you touch, plus `CLAUDE.md`. Do not assume framework or library conventions that this repository's rules do not declare.
+2. **Apply Project Standards**: Defer to the repository's own conventions — follow your rules for the languages and paths you touch. Do not assume framework or library conventions that this repository's rules do not declare.
 
 3. **Enhance Clarity**: Simplify code structure by:
 
@@ -67,7 +67,7 @@ You will analyze code and apply refinements that:
 
 1. Identify the recently modified code sections
 2. Analyze for opportunities to improve elegance and consistency
-3. Apply your rules for applicable file types and paths, and project standards from `CLAUDE.md` where they apply
+3. Apply your rules for applicable file types and paths
 4. Ensure all functionality remains unchanged
 5. Verify the refined code is simpler and more maintainable
 6. Document only significant changes that affect understanding
@@ -76,7 +76,7 @@ You will analyze code and apply refinements that:
 
 1. Enumerate or discover files under the given scope (respect excludes such as generated clients and lockfiles when the parent lists them)
 2. Analyze for simplification opportunities consistent with this skill
-3. Apply your rules for each touched file (Python rules for Python, testing rules under `tests/`, and so on), and project standards from `CLAUDE.md` where they apply
+3. Apply your rules for each touched file (Python rules for Python, testing rules under `tests/`, and so on)
 4. Ensure all functionality remains unchanged
 5. Run or specify tests the parent should run for this scope when feasible
 6. Report files changed, summary of edits, and any scope spill or contract risk

--- a/.cursor/skills/code-simplify/SKILL.md
+++ b/.cursor/skills/code-simplify/SKILL.md
@@ -13,10 +13,12 @@ The parent agent must indicate which mode applies. If unspecified, use **default
 
 - Refine code that has been **recently modified or touched in the current session**, unless explicitly instructed to review a broader scope.
 - Use this mode for day-to-day follow-up after edits in a single conversation.
+- Do not conclude "no changes needed" until you have walked each touched file against the applicable `.agents/rules/*.md` and the simplification defaults below. Report what you checked, not just what you changed.
+- Consistency with siblings counts: if a touched file inlines literals, types, or props for some siblings but not for the one you added, treat that as a finding and fix it.
 
 ### Orchestrated mode
 
-- The parent provides a **bounded scope**: explicit path list, glob, and/or service or package prefix.
+- The parent provides a **bounded scope**: explicit path list, glob, and/or service or package prefix (for example a shard under `apps/` or `packages/`).
 - You may analyze and refine **any file within that scope**, not only lines changed in the current session.
 - Use this mode when spawned as **`shard-executor`** with **`executor_kind: simplify`**, or when the user explicitly names directories or files to simplify.
 
@@ -33,7 +35,14 @@ You will analyze code and apply refinements that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
-2. **Apply Project Standards**: Defer to the repository's own conventions. Check `CLAUDE.md`, `.claude/rules/`, `.cursor/rules/`, `.agents/rules/`, and any project style/linting configuration that already exists, and follow the patterns established there. Do not invent or import standards from outside the repository — if a convention is not encoded somewhere in the repo, prefer the patterns already used in nearby code over introducing a new style.
+2. **Apply Project Standards**: Follow `.agents/rules/` for the languages and paths you touch (for example `.agents/rules/python.md`, `.agents/rules/testing.md` under `tests/`), and established standards from `CLAUDE.md` where applicable, including:
+
+   - Use modern Python type hints (`str | None`, `list[T]`, etc.)
+   - Prefer `BaseModel` over dataclasses or `TypedDict` when validation/serialization is needed
+   - Use `BaseEnum` from `vaultgig_common` for string enums
+   - Follow proper FastAPI patterns (thin route handlers, service delegation)
+   - Use appropriate log levels and the `logging` module instead of `print`
+   - Maintain consistent naming conventions
 
 3. **Enhance Clarity**: Simplify code structure by:
 
@@ -41,7 +50,7 @@ You will analyze code and apply refinements that:
    - Eliminating redundant code and abstractions
    - Improving readability through clear variable and function names
    - Consolidating related logic
-   - Removing redundant comments that restate obvious code (keep docstrings and comments that explain non-obvious **why**)
+   - Removing redundant `#` comments that restate obvious code (never treat docstrings as removable comments; keep or add one-line docstrings on functions, methods, and classes per `.agents/rules/python.md`)
    - IMPORTANT: Avoid nested ternary operators - prefer if/else chains for multiple conditions
    - Choose clarity over brevity - explicit code is often better than overly compact code
 
@@ -65,7 +74,7 @@ You will analyze code and apply refinements that:
 
 1. Identify the recently modified code sections
 2. Analyze for opportunities to improve elegance and consistency
-3. Apply the repository's own conventions (see "Apply Project Standards" above)
+3. Apply `.agents/rules/` for applicable file types and paths, and project standards from `.claude/CLAUDE.md` and `.claude/rules/` where they apply
 4. Ensure all functionality remains unchanged
 5. Verify the refined code is simpler and more maintainable
 6. Document only significant changes that affect understanding
@@ -74,7 +83,7 @@ You will analyze code and apply refinements that:
 
 1. Enumerate or discover files under the given scope (respect excludes such as generated clients and lockfiles when the parent lists them)
 2. Analyze for simplification opportunities consistent with this skill
-3. Apply the repository's own conventions (see "Apply Project Standards" above)
+3. Apply `.agents/rules/` for each touched file (for example `.agents/rules/python.md` for Python, `.agents/rules/testing.md` under `tests/`), and project standards from `.claude/CLAUDE.md` and `.claude/rules/` where they apply
 4. Ensure all functionality remains unchanged
 5. Run or specify tests the parent should run for this scope when feasible
 6. Report files changed, summary of edits, and any scope spill or contract risk


### PR DESCRIPTION
Agent config update.

---
_Generated by [Claude Code](https://claude.ai/code/session_017wz74XXFHLjRaCSohr7EYW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and hook message changes only; no runtime application or production code paths are affected.
> 
> **Overview**
> Tightens the **code-simplify** agent workflow so end-of-session reviews are real checks, not nominal skill invocations.
> 
> **Stop hooks** (`.agents`, `.claude`, `.cursor`) now block with a longer reason: agents must walk **code-simplify** against every file they changed, apply fixes, and avoid rubber-stamping “no changes needed”; they still skip when no code was modified.
> 
> The **code-simplify** skill (mirrored under `.agents`, `.claude`, `.codex`, `.cursor`) adds session-mode rules: verify each touched file before claiming nothing is needed, report what was checked, and align new code with sibling patterns (literals, types, props). Orchestrated mode clarifies bounded scope with an `apps/` / `packages/` example.
> 
> **Apply Project Standards** no longer tells agents to hunt `CLAUDE.md` / `.cursor/rules/` paths; it defers to the agent’s own language/path rules and avoids undeclared framework assumptions. Comment cleanup is narrowed to redundant `#` lines with explicit Python docstring preservation. Refinement steps reference those rules instead of “repository conventions” wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34467c70900ed1592ccc2c03b2acf78264a21a78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->