### PR TITLE
refactor: minor cleanups from a maintainability audit

### DIFF
--- a/pydantic_super_model/annotation_lookup.py
+++ b/pydantic_super_model/annotation_lookup.py
@@ -1,5 +1,5 @@
 from types import UnionType
-from typing import Annotated, Any, Union, get_args, get_origin, get_type_hints
+from typing import Annotated, Union, get_args, get_origin, get_type_hints
 
 from pydantic_super_model.annotations import AnnotatedFieldInfo
 

--- a/pydantic_super_model/mixin.py
+++ b/pydantic_super_model/mixin.py
@@ -1,6 +1,6 @@
 from pydantic_super_model.annotation_lookup import collect_annotated_fields
-from pydantic_super_model.generic_resolution import resolve_generic_type
 from pydantic_super_model.annotations import AnnotatedFieldInfo, FieldNotImplemented
+from pydantic_super_model.generic_resolution import resolve_generic_type
 
 
 class SuperModelMixin:
@@ -14,9 +14,7 @@ class SuperModelMixin:
         if not_implemented_fields:
             field_names = list(not_implemented_fields)
 
-            raise NotImplementedError(
-                f"Fields {field_names} are not implemented and should be removed."
-            )
+            raise NotImplementedError(f"Fields {field_names} are not implemented and should be removed.")
 
     def get_type(self) -> type | None:
         """Get the concrete generic type parameter for the instance."""


### PR DESCRIPTION
## Summary

A strict maintainability audit of the `pydantic_super_model/` package. The package is already cleanly factored — one concern per module, clean public API, consistent docstrings — so this is a small, behavior-preserving cleanup rather than a large restructuring. No higher-value structural change survived scrutiny (details below).

### Changes
- `annotation_lookup.py`: removed the unused `Any` import.
- `mixin.py`: fixed import ordering and reflowed the `NotImplementedError` message onto a single line within the configured 110-char limit.

### Considered but intentionally not done
- `generic_resolution.py` carries real sentinel-based caching with a clean boundary — not a slim shim; inlining it would couple concerns and add a module-level constant.
- The two `AnnotatedFieldInfo(value=None, ...)` construction sites build different metadata, so they are not true duplicates; collapsing them would add a branch, not remove one.
- The `allow_none`/`allow_undefined` flags on `get_annotated_field_value` are legitimate, tested public API — not flag bloat.

### Verification
- `pytest` → **48 passed** (unchanged from baseline).
- `black --check` and `isort --check-only` → clean.
- `pylint` → 9.71/10 (remaining findings are config-mismatch false positives only).

https://claude.ai/code/session_01PfNPPwW2cfLaSeexRGrhBw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfNPPwW2cfLaSeexRGrhBw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic import and formatting changes only; no runtime or API behavior changes.
> 
> **Overview**
> This PR is a **behavior-preserving** maintainability pass on `pydantic_super_model/`.
> 
> In **`annotation_lookup.py`**, the unused **`typing.Any`** import is removed.
> 
> In **`mixin.py`**, imports are reordered so **`generic_resolution`** follows **`annotations`**, and the **`NotImplementedError`** message in **`validate_not_implemented_fields`** is collapsed to a single line (within the 110-character line limit). No logic or public API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7910f173c103f3e45fa85d738dda0ce58f1529eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->