### PR TITLE
refactor: drop leading underscores from non-nested names

### DIFF
--- a/.github/scripts/agent_sync.py
+++ b/.github/scripts/agent_sync.py
@@ -22,7 +22,7 @@ SETTINGS_DIR: Final[Path] = AGENTS_DIR / "settings"
 MODELS_DIR: Final[Path] = AGENTS_DIR / "models"
 MAX_DIFF_LINES: Final[int] = 20
 SAFE_SLUG_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
-_TEXT_CACHE: dict[Path, str | None] = {}
+TEXT_CACHE: dict[Path, str | None] = {}
 
 
 class OutputFile(BaseModel):
@@ -691,13 +691,13 @@ def compute_diffs(outputs: list[OutputFile]) -> list[DiffEntry]:
         # Content matches but the exec bit may be missing — rewrite so write_text
         # re-applies chmod. Without this, a Stop hook command pointing at a bare
         # script path can fail.
-        if _output_needs_exec_bit(output) and output.target_path.exists() \
+        if output_needs_exec_bit(output) and output.target_path.exists() \
                 and not output.target_path.stat().st_mode & 0o111:
             diffs.append(DiffEntry(output=output, existing=existing))
     return diffs
 
 
-def _output_needs_exec_bit(output: OutputFile) -> bool:
+def output_needs_exec_bit(output: OutputFile) -> bool:
     return output.target_path.suffix == ".sh" or output.content.startswith("#!")
 
 
@@ -790,15 +790,15 @@ def compute_stale_paths(
 def read_text(path: Path) -> str | None:
     """Read a file with caching to avoid repeated disk reads."""
 
-    if path in _TEXT_CACHE:
-        return _TEXT_CACHE[path]
+    if path in TEXT_CACHE:
+        return TEXT_CACHE[path]
 
     if not path.exists():
-        _TEXT_CACHE[path] = None
+        TEXT_CACHE[path] = None
         return None
 
     content = path.read_text(encoding="utf-8")
-    _TEXT_CACHE[path] = content
+    TEXT_CACHE[path] = content
     return content
 
 
@@ -809,7 +809,7 @@ def write_text(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
     if path.suffix == ".sh" or content.startswith("#!"):
         path.chmod(0o755)
-    _TEXT_CACHE[path] = content
+    TEXT_CACHE[path] = content
 
 
 def delete_path(path: Path) -> None:
@@ -820,13 +820,13 @@ def delete_path(path: Path) -> None:
 
     if path.is_dir():
         shutil.rmtree(path)
-        stale_keys = [cached_path for cached_path in _TEXT_CACHE if cached_path.is_relative_to(path)]
+        stale_keys = [cached_path for cached_path in TEXT_CACHE if cached_path.is_relative_to(path)]
         for stale_key in stale_keys:
-            _TEXT_CACHE.pop(stale_key, None)
+            TEXT_CACHE.pop(stale_key, None)
         return
 
     path.unlink(missing_ok=True)
-    _TEXT_CACHE.pop(path, None)
+    TEXT_CACHE.pop(path, None)
 
 
 def report_diffs(diffs: list[DiffEntry], stale_paths: list[Path]) -> None:
@@ -936,7 +936,7 @@ def dedupe_directory(directory: Path) -> None:
         keep = choose_preferred(seen[digest], path)
         remove = path if keep == seen[digest] else seen[digest]
         remove.unlink(missing_ok=True)
-        _TEXT_CACHE.pop(remove, None)
+        TEXT_CACHE.pop(remove, None)
         seen[digest] = keep
 
 

--- a/pydantic_super_model/annotation_lookup.py
+++ b/pydantic_super_model/annotation_lookup.py
@@ -4,7 +4,7 @@ from typing import Annotated, Union, get_args, get_origin, get_type_hints
 from pydantic_super_model.annotations import AnnotatedFieldInfo
 
 
-def _matches_requested_annotation(candidate: object, annotations: tuple[object, ...]) -> bool:
+def matches_requested_annotation(candidate: object, annotations: tuple[object, ...]) -> bool:
     """Return whether a candidate matches any requested annotation."""
 
     for annotation in annotations:
@@ -18,7 +18,7 @@ def _matches_requested_annotation(candidate: object, annotations: tuple[object, 
     return False
 
 
-def _find_annotation_match(
+def find_annotation_match(
     annotation_type: object,
     annotations: tuple[object, ...],
 ) -> AnnotatedFieldInfo | None:
@@ -28,7 +28,7 @@ def _find_annotation_match(
 
     if origin in (Union, UnionType):
         for union_member in get_args(annotation_type):
-            match = _find_annotation_match(union_member, annotations)
+            match = find_annotation_match(union_member, annotations)
             if match is not None:
                 return match
 
@@ -39,10 +39,10 @@ def _find_annotation_match(
         matched_metadata = tuple(
             metadata_item
             for metadata_item in metadata
-            if _matches_requested_annotation(metadata_item, annotations)
+            if matches_requested_annotation(metadata_item, annotations)
         )
 
-        if matched_metadata or _matches_requested_annotation(annotation_type, annotations):
+        if matched_metadata or matches_requested_annotation(annotation_type, annotations):
             return AnnotatedFieldInfo(
                 value=None,
                 annotation=annotation_type,
@@ -50,9 +50,9 @@ def _find_annotation_match(
                 matched_metadata=matched_metadata,
             )
 
-        return _find_annotation_match(inner_type, annotations)
+        return find_annotation_match(inner_type, annotations)
 
-    if _matches_requested_annotation(annotation_type, annotations):
+    if matches_requested_annotation(annotation_type, annotations):
         return AnnotatedFieldInfo(
             value=None,
             annotation=annotation_type,
@@ -77,7 +77,7 @@ def collect_annotated_fields(
     requested_annotations = tuple(annotations)
 
     for field_name, field_type in type_hints.items():
-        annotation_match = _find_annotation_match(field_type, requested_annotations)
+        annotation_match = find_annotation_match(field_type, requested_annotations)
         if annotation_match is None:
             continue
 

--- a/pydantic_super_model/annotations.py
+++ b/pydantic_super_model/annotations.py
@@ -3,11 +3,11 @@ from typing import Any, NamedTuple
 __all__ = ["AnnotatedFieldInfo", "FieldNotImplemented"]
 
 
-class _FieldNotImplemented:
+class FieldNotImplementedMarker:
     """Mark fields that are intentionally not implemented."""
 
 
-FieldNotImplemented = _FieldNotImplemented()
+FieldNotImplemented = FieldNotImplementedMarker()
 
 
 class AnnotatedFieldInfo(NamedTuple):

--- a/pydantic_super_model/generic_resolution.py
+++ b/pydantic_super_model/generic_resolution.py
@@ -2,16 +2,16 @@ from typing import Final
 
 from generics import get_filled_type
 
-_GENERIC_TYPE_CACHE_ATTR: Final[str] = "_pydantic_super_model_cached_generic_type"
-_UNRESOLVED_GENERIC_TYPE: Final[object] = object()
+GENERIC_TYPE_CACHE_ATTR: Final[str] = "_pydantic_super_model_cached_generic_type"
+UNRESOLVED_GENERIC_TYPE: Final[object] = object()
 
 
 def resolve_generic_type(model: object, super_model_type: type[object]) -> type | None:
     """Resolve and cache the model's concrete generic type parameter."""
 
-    cached_type = getattr(model, _GENERIC_TYPE_CACHE_ATTR, _UNRESOLVED_GENERIC_TYPE)
+    cached_type = getattr(model, GENERIC_TYPE_CACHE_ATTR, UNRESOLVED_GENERIC_TYPE)
 
-    if cached_type is not _UNRESOLVED_GENERIC_TYPE:
+    if cached_type is not UNRESOLVED_GENERIC_TYPE:
         return cached_type
 
     try:
@@ -19,6 +19,6 @@ def resolve_generic_type(model: object, super_model_type: type[object]) -> type 
     except TypeError:
         resolved_type = None
 
-    setattr(model, _GENERIC_TYPE_CACHE_ATTR, resolved_type)
+    setattr(model, GENERIC_TYPE_CACHE_ATTR, resolved_type)
 
     return resolved_type

--- a/pydantic_super_model/pydantic_mixin.py
+++ b/pydantic_super_model/pydantic_mixin.py
@@ -10,7 +10,9 @@ class SuperModelPydanticMixin(SuperModelMixin, BaseModel):
     """SuperModelMixin with Pydantic auto-validation and unset-None filtering."""
 
     @model_validator(mode="after")
-    def _validate_not_implemented_fields(self) -> Self:
+    def run_not_implemented_fields_validator(self) -> Self:
+        """Reject fields marked as intentionally not implemented during validation."""
+
         self.validate_not_implemented_fields()
         return self
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,7 @@
 from pydantic_super_model import AnnotatedFieldInfo
 
 
-def _field_info(
+def build_field_info(
     value: object,
     annotation: object,
     *metadata: object,

--- a/tests/models/plain_user.py
+++ b/tests/models/plain_user.py
@@ -3,21 +3,21 @@ from typing import Annotated, Generic, TypeVar
 from pydantic_super_model import SuperModelMixin
 
 
-class _PrimaryKeyAnnotation:
+class PrimaryKeyAnnotation:
     pass
 
 
-class _ThemeColorOptions:
+class ThemeColorOptions:
     def __init__(self, *, palette: str, allow_gradients: bool) -> None:
         self.palette = palette
         self.allow_gradients = allow_gradients
 
 
-PrimaryKey = Annotated[int, _PrimaryKeyAnnotation]
+PrimaryKey = Annotated[int, PrimaryKeyAnnotation]
 ThemeColorField = Annotated[
     str,
     "theme_color",
-    _ThemeColorOptions(palette="northern-lights", allow_gradients=True),
+    ThemeColorOptions(palette="northern-lights", allow_gradients=True),
 ]
 GenericType = TypeVar("GenericType", bound=int)
 
@@ -58,10 +58,10 @@ class PlainUserWithUnionAnnotation(SuperModelMixin):
 class PlainUserWithAnnotatedAnnotation(SuperModelMixin):
     """Plain-class user test model with annotated annotation."""
 
-    id: Annotated[int, _PrimaryKeyAnnotation]
+    id: Annotated[int, PrimaryKeyAnnotation]
     name: str
 
-    def __init__(self, id: Annotated[int, _PrimaryKeyAnnotation], name: str) -> None:
+    def __init__(self, id: Annotated[int, PrimaryKeyAnnotation], name: str) -> None:
         self.id = id
         self.name = name
 

--- a/tests/models/user.py
+++ b/tests/models/user.py
@@ -3,21 +3,21 @@ from typing import Annotated, Generic, TypeVar
 from pydantic_super_model import SuperModelPydanticMixin
 
 
-class _PrimaryKeyAnnotation:
+class PrimaryKeyAnnotation:
     pass
 
 
-class _ThemeColorOptions:
+class ThemeColorOptions:
     def __init__(self, *, palette: str, allow_gradients: bool) -> None:
         self.palette = palette
         self.allow_gradients = allow_gradients
 
 
-PrimaryKey = Annotated[int, _PrimaryKeyAnnotation]
+PrimaryKey = Annotated[int, PrimaryKeyAnnotation]
 ThemeColorField = Annotated[
     str,
     "theme_color",
-    _ThemeColorOptions(palette="northern-lights", allow_gradients=True),
+    ThemeColorOptions(palette="northern-lights", allow_gradients=True),
 ]
 GenericType = TypeVar("GenericType", bound=int)
 
@@ -46,7 +46,7 @@ class UserWithUnionAnnotation(SuperModelPydanticMixin):
 class UserWithAnnotatedAnnotation(SuperModelPydanticMixin):
     """User test model with annotated annotation."""
 
-    id: Annotated[int, _PrimaryKeyAnnotation]
+    id: Annotated[int, PrimaryKeyAnnotation]
     name: str
 
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -36,6 +36,13 @@ class TestAnnotatedFields:
 
         assert not user.get_annotated_fields(PrimaryKey)
 
+    def test_matches_fields_typed_as_a_requested_bare_type(self) -> None:
+        """Match a field whose type hint is exactly a requested type."""
+
+        user = UserNoAnnotations(id=1, name="John Doe")
+
+        assert user.get_annotated_fields(int) == {"id": build_field_info(1, int)}
+
     def test_returns_empty_when_no_annotations_are_requested(self) -> None:
         """Return an empty mapping when no annotations are provided."""
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -3,7 +3,7 @@ from typing import Annotated
 import pytest
 
 from pydantic_super_model import SuperModelPydanticMixin
-from tests.helpers import _field_info
+from tests.helpers import build_field_info
 from tests.models.user import (
     PrimaryKey,
     ThemeColorField,
@@ -12,8 +12,8 @@ from tests.models.user import (
     UserNoAnnotations,
     UserWithAnnotatedAnnotation,
     UserWithUnionAnnotation,
-    _PrimaryKeyAnnotation,
-    _ThemeColorOptions,
+    PrimaryKeyAnnotation,
+    ThemeColorOptions,
 )
 
 
@@ -27,7 +27,7 @@ class TestAnnotatedFields:
 
         annotated_fields = user.get_annotated_fields(PrimaryKey)
 
-        assert annotated_fields == {"id": _field_info(1, PrimaryKey, _PrimaryKeyAnnotation)}
+        assert annotated_fields == {"id": build_field_info(1, PrimaryKey, PrimaryKeyAnnotation)}
 
     def test_returns_empty_when_model_has_no_annotations(self) -> None:
         """Return an empty mapping when no matching annotations exist."""
@@ -49,7 +49,7 @@ class TestAnnotatedFields:
         user = UserWithUnionAnnotation(id=1, name="John Doe")
 
         assert user.get_annotated_fields(PrimaryKey) == {
-            "id": _field_info(1, PrimaryKey, _PrimaryKeyAnnotation)
+            "id": build_field_info(1, PrimaryKey, PrimaryKeyAnnotation)
         }
 
     def test_matches_annotations_with_direct_annotated_types(self) -> None:
@@ -58,7 +58,7 @@ class TestAnnotatedFields:
         user = UserWithAnnotatedAnnotation(id=1, name="John Doe")
 
         assert user.get_annotated_fields(PrimaryKey) == {
-            "id": _field_info(1, PrimaryKey, _PrimaryKeyAnnotation)
+            "id": build_field_info(1, PrimaryKey, PrimaryKeyAnnotation)
         }
 
     def test_includes_explicit_none_values(self) -> None:
@@ -73,7 +73,7 @@ class TestAnnotatedFields:
         user = _UserOptionalPrimaryKey(id=None, name="John Doe")
 
         assert user.get_annotated_fields(PrimaryKey) == {
-            "id": _field_info(None, PrimaryKey, _PrimaryKeyAnnotation)
+            "id": build_field_info(None, PrimaryKey, PrimaryKeyAnnotation)
         }
 
     def test_includes_falsy_non_none_values(self) -> None:
@@ -82,7 +82,7 @@ class TestAnnotatedFields:
         user = User(id=0, name="Zero")
 
         assert user.get_annotated_fields(PrimaryKey) == {
-            "id": _field_info(0, PrimaryKey, _PrimaryKeyAnnotation)
+            "id": build_field_info(0, PrimaryKey, PrimaryKeyAnnotation)
         }
 
     def test_matches_metadata_annotation_classes(self) -> None:
@@ -91,20 +91,20 @@ class TestAnnotatedFields:
         user = User(id=1, name="John Doe")
         annotated_user = UserWithAnnotatedAnnotation(id=2, name="Jane")
 
-        assert user.get_annotated_fields(_PrimaryKeyAnnotation) == {
-            "id": _field_info(
+        assert user.get_annotated_fields(PrimaryKeyAnnotation) == {
+            "id": build_field_info(
                 1,
                 PrimaryKey,
-                _PrimaryKeyAnnotation,
-                matched_metadata=(_PrimaryKeyAnnotation,),
+                PrimaryKeyAnnotation,
+                matched_metadata=(PrimaryKeyAnnotation,),
             )
         }
-        assert annotated_user.get_annotated_fields(_PrimaryKeyAnnotation) == {
-            "id": _field_info(
+        assert annotated_user.get_annotated_fields(PrimaryKeyAnnotation) == {
+            "id": build_field_info(
                 2,
                 PrimaryKey,
-                _PrimaryKeyAnnotation,
-                matched_metadata=(_PrimaryKeyAnnotation,),
+                PrimaryKeyAnnotation,
+                matched_metadata=(PrimaryKeyAnnotation,),
             )
         }
 
@@ -125,7 +125,7 @@ class TestAnnotatedFields:
         model = _ModelWithTwoAnnotatedFields(first=1, second=2)
 
         assert model.get_annotated_fields(_OtherAnnotation) == {
-            "second": _field_info(
+            "second": build_field_info(
                 2,
                 other_annotation,
                 _OtherAnnotation,
@@ -133,14 +133,14 @@ class TestAnnotatedFields:
             )
         }
 
-        assert model.get_annotated_fields(_PrimaryKeyAnnotation, _OtherAnnotation) == {
-            "first": _field_info(
+        assert model.get_annotated_fields(PrimaryKeyAnnotation, _OtherAnnotation) == {
+            "first": build_field_info(
                 1,
                 PrimaryKey,
-                _PrimaryKeyAnnotation,
-                matched_metadata=(_PrimaryKeyAnnotation,),
+                PrimaryKeyAnnotation,
+                matched_metadata=(PrimaryKeyAnnotation,),
             ),
-            "second": _field_info(
+            "second": build_field_info(
                 2,
                 other_annotation,
                 _OtherAnnotation,
@@ -154,21 +154,21 @@ class TestAnnotatedFields:
         class _NestedModel(SuperModelPydanticMixin):
             """Model with nested unions carrying annotated members."""
 
-            id: (Annotated[int, _PrimaryKeyAnnotation] | str) | float
+            id: (Annotated[int, PrimaryKeyAnnotation] | str) | float
             name: str
 
         int_model = _NestedModel(id=123, name="A")
         str_model = _NestedModel(id="x", name="B")
 
-        expected = _field_info(
+        expected = build_field_info(
             123,
-            Annotated[int, _PrimaryKeyAnnotation],
-            _PrimaryKeyAnnotation,
-            matched_metadata=(_PrimaryKeyAnnotation,),
+            Annotated[int, PrimaryKeyAnnotation],
+            PrimaryKeyAnnotation,
+            matched_metadata=(PrimaryKeyAnnotation,),
         )
 
-        assert int_model.get_annotated_fields(_PrimaryKeyAnnotation) == {"id": expected}
-        assert str_model.get_annotated_fields(_PrimaryKeyAnnotation) == {
+        assert int_model.get_annotated_fields(PrimaryKeyAnnotation) == {"id": expected}
+        assert str_model.get_annotated_fields(PrimaryKeyAnnotation) == {
             "id": expected._replace(value="x")
         }
 
@@ -186,7 +186,7 @@ class TestAnnotatedFields:
 
         assert not unset_user.get_annotated_fields(PrimaryKey)
         assert explicit_user.get_annotated_fields(PrimaryKey) == {
-            "id": _field_info(None, PrimaryKey, _PrimaryKeyAnnotation)
+            "id": build_field_info(None, PrimaryKey, PrimaryKeyAnnotation)
         }
 
     def test_returns_empty_for_unknown_annotations(self) -> None:
@@ -204,11 +204,11 @@ class TestAnnotatedFields:
 
         theme = ThemeConfig(accent_color="#7dd3fc", theme_name="Aurora")
 
-        annotated_fields = theme.get_annotated_fields(_ThemeColorOptions)
+        annotated_fields = theme.get_annotated_fields(ThemeColorOptions)
         field_info = annotated_fields["accent_color"]
         matched_metadata = field_info.matched_metadata
 
-        assert field_info == _field_info(
+        assert field_info == build_field_info(
             "#7dd3fc",
             ThemeColorField,
             "theme_color",
@@ -216,7 +216,7 @@ class TestAnnotatedFields:
             matched_metadata=matched_metadata,
         )
         assert len(matched_metadata) == 1
-        assert isinstance(matched_metadata[0], _ThemeColorOptions)
+        assert isinstance(matched_metadata[0], ThemeColorOptions)
         assert matched_metadata[0].palette == "northern-lights"
         assert matched_metadata[0].allow_gradients is True
 
@@ -231,7 +231,7 @@ class TestAnnotatedFields:
         user = _InheritedUser(id=5, name="Taylor", email="taylor@example.com")
 
         assert user.get_annotated_fields(PrimaryKey) == {
-            "id": _field_info(5, PrimaryKey, _PrimaryKeyAnnotation)
+            "id": build_field_info(5, PrimaryKey, PrimaryKeyAnnotation)
         }
 
 
@@ -243,10 +243,10 @@ class TestAnnotatedFieldValue:
 
         user = User(id=7, name="Jane")
 
-        assert user.get_annotated_field_value(PrimaryKey) == _field_info(
+        assert user.get_annotated_field_value(PrimaryKey) == build_field_info(
             7,
             PrimaryKey,
-            _PrimaryKeyAnnotation,
+            PrimaryKeyAnnotation,
         )
 
     def test_raises_when_no_matching_field_exists(self) -> None:
@@ -289,10 +289,10 @@ class TestAnnotatedFieldValue:
 
         model = _OptionalPrimaryKeyModel(id=None, name="N")
 
-        assert model.get_annotated_field_value(PrimaryKey, allow_none=True) == _field_info(
+        assert model.get_annotated_field_value(PrimaryKey, allow_none=True) == build_field_info(
             None,
             PrimaryKey,
-            _PrimaryKeyAnnotation,
+            PrimaryKeyAnnotation,
         )
 
     def test_returns_field_info_for_falsy_values(self) -> None:
@@ -300,24 +300,24 @@ class TestAnnotatedFieldValue:
 
         user = User(id=0, name="Zero")
 
-        assert user.get_annotated_field_value(PrimaryKey) == _field_info(
+        assert user.get_annotated_field_value(PrimaryKey) == build_field_info(
             0,
             PrimaryKey,
-            _PrimaryKeyAnnotation,
+            PrimaryKeyAnnotation,
         )
 
     def test_returns_field_info_with_metadata_instances(self) -> None:
         """Return matched metadata instances for class-based lookup."""
 
         theme = ThemeConfig(accent_color="#7dd3fc", theme_name="Aurora")
-        field_info = theme.get_annotated_field_value(_ThemeColorOptions)
+        field_info = theme.get_annotated_field_value(ThemeColorOptions)
 
         assert field_info is not None
         assert field_info.value == "#7dd3fc"
         assert field_info.annotation == ThemeColorField
         assert field_info.metadata[0] == "theme_color"
         assert len(field_info.matched_metadata) == 1
-        assert isinstance(field_info.matched_metadata[0], _ThemeColorOptions)
+        assert isinstance(field_info.matched_metadata[0], ThemeColorOptions)
 
     def test_returns_the_first_match_in_field_definition_order(self) -> None:
         """Return the first matching field based on model field order."""
@@ -330,8 +330,8 @@ class TestAnnotatedFieldValue:
 
         model = _TwoPrimaryKeys(first_id=1, second_id=2)
 
-        assert model.get_annotated_field_value(PrimaryKey) == _field_info(
+        assert model.get_annotated_field_value(PrimaryKey) == build_field_info(
             1,
             PrimaryKey,
-            _PrimaryKeyAnnotation,
+            PrimaryKeyAnnotation,
         )

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -3,7 +3,7 @@ from typing import Annotated
 import pytest
 
 from pydantic_super_model import SuperModelMixin, FieldNotImplemented
-from tests.helpers import _field_info
+from tests.helpers import build_field_info
 from tests.models.plain_user import (
     PlainThemeConfig,
     PlainUser,
@@ -13,8 +13,8 @@ from tests.models.plain_user import (
     PlainUserWithUnionAnnotation,
     PrimaryKey,
     ThemeColorField,
-    _PrimaryKeyAnnotation,
-    _ThemeColorOptions,
+    PrimaryKeyAnnotation,
+    ThemeColorOptions,
 )
 
 
@@ -28,7 +28,7 @@ class TestPlainClassAnnotatedFields:
 
         annotated_fields = user.get_annotated_fields(PrimaryKey)
 
-        assert annotated_fields == {"id": _field_info(1, PrimaryKey, _PrimaryKeyAnnotation)}
+        assert annotated_fields == {"id": build_field_info(1, PrimaryKey, PrimaryKeyAnnotation)}
 
     def test_returns_empty_when_model_has_no_annotations(self) -> None:
         """Return an empty mapping when no matching annotations exist."""
@@ -50,7 +50,7 @@ class TestPlainClassAnnotatedFields:
         user = PlainUserWithUnionAnnotation(id=1, name="John Doe")
 
         assert user.get_annotated_fields(PrimaryKey) == {
-            "id": _field_info(1, PrimaryKey, _PrimaryKeyAnnotation)
+            "id": build_field_info(1, PrimaryKey, PrimaryKeyAnnotation)
         }
 
     def test_matches_annotations_with_direct_annotated_types(self) -> None:
@@ -59,7 +59,7 @@ class TestPlainClassAnnotatedFields:
         user = PlainUserWithAnnotatedAnnotation(id=1, name="John Doe")
 
         assert user.get_annotated_fields(PrimaryKey) == {
-            "id": _field_info(1, PrimaryKey, _PrimaryKeyAnnotation)
+            "id": build_field_info(1, PrimaryKey, PrimaryKeyAnnotation)
         }
 
     def test_includes_none_values(self) -> None:
@@ -76,7 +76,7 @@ class TestPlainClassAnnotatedFields:
         user = _PlainOptionalPK(name="A")
 
         assert user.get_annotated_fields(PrimaryKey) == {
-            "id": _field_info(None, PrimaryKey, _PrimaryKeyAnnotation)
+            "id": build_field_info(None, PrimaryKey, PrimaryKeyAnnotation)
         }
 
     def test_includes_falsy_non_none_values(self) -> None:
@@ -85,7 +85,7 @@ class TestPlainClassAnnotatedFields:
         user = PlainUser(id=0, name="Zero")
 
         assert user.get_annotated_fields(PrimaryKey) == {
-            "id": _field_info(0, PrimaryKey, _PrimaryKeyAnnotation)
+            "id": build_field_info(0, PrimaryKey, PrimaryKeyAnnotation)
         }
 
     def test_matches_metadata_annotation_classes(self) -> None:
@@ -93,12 +93,12 @@ class TestPlainClassAnnotatedFields:
 
         user = PlainUser(id=1, name="John Doe")
 
-        assert user.get_annotated_fields(_PrimaryKeyAnnotation) == {
-            "id": _field_info(
+        assert user.get_annotated_fields(PrimaryKeyAnnotation) == {
+            "id": build_field_info(
                 1,
                 PrimaryKey,
-                _PrimaryKeyAnnotation,
-                matched_metadata=(_PrimaryKeyAnnotation,),
+                PrimaryKeyAnnotation,
+                matched_metadata=(PrimaryKeyAnnotation,),
             )
         }
 
@@ -107,11 +107,11 @@ class TestPlainClassAnnotatedFields:
 
         theme = PlainThemeConfig(accent_color="#7dd3fc", theme_name="Aurora")
 
-        annotated_fields = theme.get_annotated_fields(_ThemeColorOptions)
+        annotated_fields = theme.get_annotated_fields(ThemeColorOptions)
         field_info = annotated_fields["accent_color"]
         matched_metadata = field_info.matched_metadata
 
-        assert field_info == _field_info(
+        assert field_info == build_field_info(
             "#7dd3fc",
             ThemeColorField,
             "theme_color",
@@ -119,7 +119,7 @@ class TestPlainClassAnnotatedFields:
             matched_metadata=matched_metadata,
         )
         assert len(matched_metadata) == 1
-        assert isinstance(matched_metadata[0], _ThemeColorOptions)
+        assert isinstance(matched_metadata[0], ThemeColorOptions)
         assert matched_metadata[0].palette == "northern-lights"
         assert matched_metadata[0].allow_gradients is True
 
@@ -132,10 +132,10 @@ class TestPlainClassAnnotatedFieldValue:
 
         user = PlainUser(id=7, name="Jane")
 
-        assert user.get_annotated_field_value(PrimaryKey) == _field_info(
+        assert user.get_annotated_field_value(PrimaryKey) == build_field_info(
             7,
             PrimaryKey,
-            _PrimaryKeyAnnotation,
+            PrimaryKeyAnnotation,
         )
 
     def test_raises_when_no_matching_field_exists(self) -> None:
@@ -158,10 +158,10 @@ class TestPlainClassAnnotatedFieldValue:
 
         user = PlainUser(id=0, name="Zero")
 
-        assert user.get_annotated_field_value(PrimaryKey) == _field_info(
+        assert user.get_annotated_field_value(PrimaryKey) == build_field_info(
             0,
             PrimaryKey,
-            _PrimaryKeyAnnotation,
+            PrimaryKeyAnnotation,
         )
 
 


### PR DESCRIPTION
## Summary

Enforces the updated leading-underscore convention: a leading underscore is allowed **only** for nested definitions (a function inside another function/method, a class inside another class). All other names — module-level functions/classes/constants/type-aliases, methods, and underscore-prefixed modules — drop the leading underscore.

### Changes
- `pydantic_super_model/`: dropped underscores from module-level helpers/constants and renamed the `_FieldNotImplemented` sentinel **class** to `FieldNotImplementedMarker` (the public `FieldNotImplemented` instance already owns the bare name — collision avoided), updating all references.
- `.github/scripts/agent_sync.py`: `_TEXT_CACHE` → `TEXT_CACHE`, `_output_needs_exec_bit` → `output_needs_exec_bit`.
- Tests updated to the new names (helpers, model fixtures, references).

Nested inner functions/closures, dunders, and third-party names are left untouched.

### Verification
- `pytest` → **48 passed**.
- Grep confirms no remaining in-scope leading-underscore definitions.

https://claude.ai/code/session_01PfNPPwW2cfLaSeexRGrhBw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfNPPwW2cfLaSeexRGrhBw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical renames and test updates only; public `FieldNotImplemented` API unchanged and pytest reported passing.
> 
> **Overview**
> Aligns the codebase with an updated **leading-underscore naming rule**: module-level helpers, constants, and methods drop the `_` prefix unless they are truly nested definitions.
> 
> In **`pydantic_super_model`**, internal helpers and cache symbols are renamed (e.g. `find_annotation_match`, `TEXT_CACHE`-style constants in generic resolution), the not-implemented sentinel class becomes **`FieldNotImplementedMarker`** while the public **`FieldNotImplemented`** instance stays the same, and the Pydantic after-validator is renamed to **`run_not_implemented_fields_validator`** with a docstring. **`.github/scripts/agent_sync.py`** gets the same treatment for its file cache and exec-bit helper.
> 
> Tests and fixtures are updated to the new names (`build_field_info`, `PrimaryKeyAnnotation`, etc.), plus one new case that **`get_annotated_fields(int)`** matches a field whose hint is a bare requested type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a42b6e71de03858a7adaf89495eae5d4f095fbad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->