### PR TITLE
Update code review workflow settings

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -29,8 +29,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', github.event.issue.number) }}
       - uses: julien777z/code-review-action@v0
         with:
-          cursor-api-key: ${{ secrets.CURSOR_API_KEY }}
-          review-model: cursor
+          codex-auth-json: ${{ secrets.CODEX_AUTH_JSON }}
           author-associations: OWNER,MEMBER,COLLABORATOR
           pr-review-summary: "true"
           enforce-project-rules: "true"

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -25,6 +25,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', github.event.issue.number) }}
       - uses: julien777z/code-review-action@v0
         with:
           cursor-api-key: ${{ secrets.CURSOR_API_KEY }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -14,12 +14,25 @@ permissions:
 jobs:
   Review:
     runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository)
+      || (github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && startsWith(github.event.comment.body, 'agent review'))
     concurrency:
       group: code-review-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name == 'issue_comment' && 'comment' || 'review' }}
       cancel-in-progress: true
     steps:
+      - uses: actions/checkout@v4
       - uses: julien777z/code-review-action@v0
         with:
           cursor-api-key: ${{ secrets.CURSOR_API_KEY }}
           review-model: cursor
           author-associations: OWNER,MEMBER,COLLABORATOR
+          pr-review-summary: "true"
+          enforce-project-rules: "true"
+          project-rules-severity: "medium"
+          simplify-suggest: "true"
+          simplify-suggest-severity: "medium"
+          simplify-nearby-code: "true"


### PR DESCRIPTION
## Summary
- Check out the repository before running the code review action so project rules can be loaded from `.cursor/rules`.
- Enable PR review summaries, project rule enforcement, and simplification suggestions at medium severity.
- Limit automatic reviews to same-repo pull requests and `agent review` issue comments.

## Test plan
- [ ] Open or update a pull request and confirm the Code Review workflow runs successfully.

<!-- code-review:summary:start -->
---
<!-- UNTRUSTED_INPUT START -->
### Summary
- Restricts the code review workflow to same-repo pull requests and to issue comments on PRs that start with `agent review`
- Adds an explicit `actions/checkout@v4` step before running the review action
- Enables PR review summaries via `pr-review-summary`
- Turns on project rules enforcement at medium severity
- Enables simplify suggestions and nearby-code simplification at medium severity
- Keeps concurrency grouping so overlapping review runs for the same PR are cancelled

**Low Risk** — This only updates GitHub Actions workflow configuration for automated reviews and does not change application runtime code.

### Overview
This pull request updates the `code-review` GitHub Actions workflow to run under tighter event conditions (excluding fork PRs unless triggered by a qualifying comment), check out the repository before invoking `julien777z/code-review-action@v0`, and pass several new action inputs that enable richer review output, project-rules enforcement, and code-simplification suggestions at medium severity.
<!-- UNTRUSTED_INPUT END -->

_This response was AI generated by [code-review-action](https://github.com/julien777z/code-review-action)._
<!-- code-review:summary:end -->