### PR TITLE
Enable default Codex user input

### DIFF
--- a/.agents/settings/codex.json
+++ b/.agents/settings/codex.json
@@ -1,3 +1,6 @@
 {
-  "project_doc_max_bytes": 56614
+  "project_doc_max_bytes": 56614,
+  "features": {
+    "default_mode_request_user_input": true
+  }
 }


### PR DESCRIPTION
## Summary

- enable `default_mode_request_user_input` in canonical Codex settings
- allow the generated project configuration to expose the user-input tool in default mode

## Validation

- canonical settings parsed through the typed Codex generator
- generated TOML parsed successfully
- `git diff --check`